### PR TITLE
Handle case where property is expected to be null

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.js]
+indent_style = space
+indent_size = 2

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,8 @@ module.exports = ({ Assertion }) => {
     hasSameType: (actual, expected) => new Assertion(actual).to.be.a(typeof expected),
     hasSameConstructor: (actual, expected) => new Assertion(actual.constructor).to.equal(expected.constructor),
     hasConstructor: (obj, constructor) => new Assertion(obj.constructor).to.equal(constructor),
-    hasProperty: (obj, prop) => new Assertion(obj).to.have.property(prop)
+    hasProperty: (obj, prop) => new Assertion(obj).to.have.property(prop),
+    isNull: actual => new Assertion(actual).to.be.null
   }
   
   let isObject = (obj) => typeof obj === "object" && obj !== null
@@ -45,6 +46,8 @@ module.exports = ({ Assertion }) => {
         compareObjects(actualValue, expectedValue)
       } else if (isFunction(expectedValue)) {
         compareFunctions(actualValue, expectedValue)
+      } else if (expectedValue === null) {
+        assert.isNull(actualValue)
       } else {
         assert.hasSameType(actualValue, expectedValue)
       }


### PR DESCRIPTION
Heya @xasdx, came across this because it kept throwing the following error:

```
AssertionError: expected null to be an object
```

Because the else matches on `null`s, and the code run then is the same as what I showed here in my console:

```
> chai.expect(null).to.be.a(typeof null)
AssertionError: expected null to be an object
```

This fixes that by just checking if `expectedValue` is `null`, and if it is then run the equivalent of `expect(actualValue).to.be.null`.

As a bonus, I added a [.editorconfig file](https://editorconfig.org/).